### PR TITLE
Test: Add caching get_body class to Observer. Use it.

### DIFF
--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -16,7 +16,7 @@ import warnings
 # Third-party
 from astropy.time import Time
 import astropy.units as u
-from astropy.coordinates import get_body, get_sun, Galactic, SkyCoord
+from astropy.coordinates import Galactic, SkyCoord
 from astropy import table
 
 import numpy as np
@@ -471,7 +471,7 @@ class AtNightConstraint(Constraint):
                     observer.pressure = 0
 
                 # find solar altitude at these times
-                altaz = observer.altaz(times, get_sun(times))
+                altaz = observer.altaz(times, observer.get_body('sun', times))
                 altitude = altaz.alt
                 # cache the altitude
                 observer._altaz_cache[aakey] = dict(times=times,
@@ -549,7 +549,7 @@ class SunSeparationConstraint(Constraint):
         # centred frame, so the separation is as-seen
         # by the observer.
         # 'get_sun' returns ICRS coords.
-        sun = get_body('sun', times, location=observer.location)
+        sun = observer.get_body('sun', times)
         targets = get_skycoord(targets)
         solar_separation = sun.separation(targets)
 
@@ -591,7 +591,7 @@ class MoonSeparationConstraint(Constraint):
         self.ephemeris = ephemeris
 
     def compute_constraint(self, times, observer, targets):
-        moon = get_body("moon", times, location=observer.location, ephemeris=self.ephemeris)
+        moon = observer.get_body("moon", times, ephemeris=self.ephemeris)
         # note to future editors - the order matters here
         # moon.separation(targets) is NOT the same as targets.separation(moon)
         # the former calculates the separation in the frame of the moon coord

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -27,6 +27,7 @@ from .moon import moon_illumination
 from .utils import time_grid_from_range
 from .target import get_skycoord
 from .exceptions import MissingConstraintWarning
+from .observer import _make_cache_key
 
 __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
@@ -42,47 +43,6 @@ _current_year_time_range = Time(  # needed for backward compatibility
     [str(_current_year) + '-01-01',
      str(_current_year) + '-12-31']
 )
-
-
-def _make_cache_key(times, targets):
-    """
-    Make a unique key to reference this combination of ``times`` and ``targets``.
-
-    Often, we wish to store expensive calculations for a combination of
-    ``targets`` and ``times`` in a cache on an ``observer``` object. This
-    routine will provide an appropriate, hashable, key to store these
-    calculations in a dictionary.
-
-    Parameters
-    ----------
-    times : `~astropy.time.Time`
-        Array of times on which to test the constraint.
-    targets : `~astropy.coordinates.SkyCoord`
-        Target or list of targets.
-
-    Returns
-    -------
-    cache_key : tuple
-        A hashable tuple for use as a cache key
-    """
-    # make a tuple from times
-    try:
-        timekey = tuple(times.jd) + times.shape
-    except BaseException:        # must be scalar
-        timekey = (times.jd,)
-    # make hashable thing from targets coords
-    try:
-        if hasattr(targets, 'frame'):
-            # treat as a SkyCoord object. Accessing the longitude
-            # attribute of the frame data should be unique and is
-            # quicker than accessing the ra attribute.
-            targkey = tuple(targets.frame.data.lon.value.ravel()) + targets.shape
-        else:
-            # assume targets is a string.
-            targkey = (targets,)
-    except BaseException:
-        targkey = (targets.frame.data.lon,)
-    return timekey + targkey
 
 
 def _get_altaz(times, observer, targets, force_zero_pressure=False):

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -423,7 +423,7 @@ class AtNightConstraint(Constraint):
         if not hasattr(observer, '_altaz_cache'):
             observer._altaz_cache = {}
 
-        aakey = _make_cache_key(times, "sun")
+        aakey = _make_cache_key(times, 'sun')
 
         if aakey not in observer._altaz_cache:
             try:
@@ -510,7 +510,7 @@ class SunSeparationConstraint(Constraint):
         # centred frame, so the separation is as-seen
         # by the observer.
         # 'get_sun' returns ICRS coords.
-        sun = observer.get_body("sun", times)
+        sun = observer.get_body('sun', times)
         targets = get_skycoord(targets)
         solar_separation = sun.separation(targets)
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -423,7 +423,7 @@ class AtNightConstraint(Constraint):
         if not hasattr(observer, '_altaz_cache'):
             observer._altaz_cache = {}
 
-        aakey = _make_cache_key(times, 'sun')
+        aakey = _make_cache_key(times, "sun")
 
         if aakey not in observer._altaz_cache:
             try:
@@ -432,7 +432,7 @@ class AtNightConstraint(Constraint):
                     observer.pressure = 0
 
                 # find solar altitude at these times
-                altaz = observer.altaz(times, observer.get_body('sun', times))
+                altaz = observer.altaz(times, observer.get_body("sun", times))
                 altitude = altaz.alt
                 # cache the altitude
                 observer._altaz_cache[aakey] = dict(times=times,
@@ -510,7 +510,7 @@ class SunSeparationConstraint(Constraint):
         # centred frame, so the separation is as-seen
         # by the observer.
         # 'get_sun' returns ICRS coords.
-        sun = observer.get_body('sun', times)
+        sun = observer.get_body("sun", times)
         targets = get_skycoord(targets)
         solar_separation = sun.separation(targets)
 

--- a/astroplan/constraints.py
+++ b/astroplan/constraints.py
@@ -29,6 +29,7 @@ from .target import get_skycoord
 from .exceptions import MissingConstraintWarning
 from .observer import _make_cache_key
 
+
 __all__ = ["AltitudeConstraint", "AirmassConstraint", "AtNightConstraint",
            "is_observable", "is_always_observable", "time_grid_from_range",
            "GalacticLatitudeConstraint", "SunSeparationConstraint",

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 # Standard library
 import sys
+import datetime
 import warnings
 # Third-party
 from astropy.coordinates import (EarthLocation, SkyCoord, AltAz,

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from six import string_types
 
 # Standard library
 import sys
-import datetime
 import warnings
 # Third-party
 from astropy.coordinates import (EarthLocation, SkyCoord, AltAz,
@@ -19,8 +17,9 @@ import pytz
 # Package
 from .exceptions import TargetNeverUpWarning, TargetAlwaysUpWarning
 from .moon import moon_illumination, moon_phase_angle
-from .target import get_skycoord, SunFlag, MoonFlag
 from .observer import _make_cache_key
+from .target import MoonFlag, SunFlag, get_skycoord
+
 
 __all__ = ["Observer"]
 

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -607,7 +607,7 @@ class Observer(object):
         >>> from astropy.coordinates import SkyCoord
         >>> apo = Observer.at_site("APO")
         >>> time = Time('2001-02-03 04:05:06')
-        >>> target = apo.get_body('sun', time)
+        >>> target = apo.get_body("sun", time)
         """
         if not isinstance(time, Time):
             time = Time(time)
@@ -687,7 +687,7 @@ class Observer(object):
             if target is MoonFlag:
                 target = self.get_body("moon", time)
             elif target is SunFlag:
-                target = self.get_body('sun', time)
+                target = self.get_body("sun", time)
 
             time, target = self._preprocess_inputs(time, target, grid_times_targets)
 
@@ -1440,7 +1440,7 @@ class Observer(object):
         >>> print("ISO: {0.iso}, JD: {0.jd}".format(sun_rise)) # doctest: +SKIP
         ISO: 2001-02-02 14:02:50.554, JD: 2451943.08531
         """
-        return self.target_rise_time(time, self.get_body('sun', time), which, horizon,
+        return self.target_rise_time(time, self.get_body("sun", time), which, horizon,
                                      n_grid_points=n_grid_points)
 
     @u.quantity_input(horizon=u.deg)
@@ -1491,7 +1491,7 @@ class Observer(object):
         >>> print("ISO: {0.iso}, JD: {0.jd}".format(sun_set)) # doctest: +SKIP
         ISO: 2001-02-04 00:35:42.102, JD: 2451944.52479
         """
-        return self.target_set_time(time, self.get_body('sun', time), which, horizon,
+        return self.target_set_time(time, self.get_body("sun", time), which, horizon,
                                     n_grid_points=n_grid_points)
 
     def noon(self, time, which='nearest', n_grid_points=150):
@@ -1520,7 +1520,7 @@ class Observer(object):
         `~astropy.time.Time`
             Time at solar noon
         """
-        return self.target_meridian_transit_time(time, self.get_body('sun', time), which,
+        return self.target_meridian_transit_time(time, self.get_body("sun", time), which,
                                                  n_grid_points=n_grid_points)
 
     def midnight(self, time, which='nearest', n_grid_points=150):
@@ -1549,7 +1549,7 @@ class Observer(object):
         `~astropy.time.Time`
             Time at solar midnight
         """
-        return self.target_meridian_antitransit_time(time, self.get_body('sun', time), which,
+        return self.target_meridian_antitransit_time(time, self.get_body("sun", time), which,
                                                      n_grid_points=n_grid_points)
 
     # Twilight convenience functions
@@ -1935,7 +1935,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        sun = self.get_body('sun', time)
+        sun = self.get_body("sun", time)
         return self.altaz(time, sun)
 
     @u.quantity_input(horizon=u.deg)
@@ -2045,7 +2045,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        solar_altitude = self.altaz(time, target=self.get_body('sun', time), obswl=obswl).alt
+        solar_altitude = self.altaz(time, target=self.get_body("sun", time), obswl=obswl).alt
 
         if solar_altitude.isscalar:
             return bool(solar_altitude < horizon)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -8,7 +8,7 @@ import sys
 import datetime
 import warnings
 # Third-party
-from astropy.coordinates import (EarthLocation, SkyCoord, AltAz, get_sun,
+from astropy.coordinates import (EarthLocation, SkyCoord, AltAz,
                                  get_body, Angle, Longitude)
 import astropy.units as u
 from astropy.time import Time
@@ -20,7 +20,7 @@ import pytz
 from .exceptions import TargetNeverUpWarning, TargetAlwaysUpWarning
 from .moon import moon_illumination, moon_phase_angle
 from .target import get_skycoord, SunFlag, MoonFlag
-
+from .observer import _make_cache_key
 
 __all__ = ["Observer"]
 
@@ -531,6 +531,58 @@ class Observer(object):
                              .format(time.shape, target.shape))
         return time, target
 
+    def get_body(self, body, time, ephemeris=None):
+        """
+        Get a solar system body from `~astropy.coordinates.get_body` for the
+        current observer location. Results are cached to speed up multiple
+        calls for the same body and time.
+
+        Parameters
+        ----------
+        body : str
+            Name of solar system body.
+
+        time : `~astropy.time.Time` or other (see below)
+            The time at which the observation is taking place. Will be used as
+            the ``obstime`` attribute in the resulting frame or coordinate. This
+            will be passed in as the first argument to the `~astropy.time.Time`
+            initializer, so it can be anything that `~astropy.time.Time` will
+            accept (including a `~astropy.time.Time` object)
+
+        ephemeris : str, optional
+            Ephemeris to use.  If not given, use the one set with
+            ``astropy.coordinates.solar_system_ephemeris.set`` (which is
+            set to 'builtin' by default).
+
+        Returns
+        -------
+        `~astropy.coordinates.SkyCoord`
+            The position of the solar system body at the requested time.
+
+        Examples
+        --------
+        >>> from astroplan import Observer
+        >>> from astropy.time import Time
+        >>> from astropy.coordinates import SkyCoord
+        >>> apo = Observer.at_site("APO")
+        >>> time = Time('2001-02-03 04:05:06')
+        >>> target = apo.get_body('sun', time)
+        """
+        if not isinstance(time, Time):
+            time = Time(time)
+
+        _cache_key = _make_cache_key(time, body)
+
+        if not hasattr(self, "_body_cache"):
+            self._body_cache = {}
+
+        if _cache_key not in self._body_cache:
+            self._body_cache[_cache_key] = get_body(
+                body, time, location=self.location, ephemeris=ephemeris
+            )
+
+        return self._body_cache[_cache_key]
+
     def altaz(self, time, target=None, obswl=None, grid_times_targets=False):
         """
         Get an `~astropy.coordinates.AltAz` frame or coordinate.
@@ -592,9 +644,9 @@ class Observer(object):
         """
         if target is not None:
             if target is MoonFlag:
-                target = get_body("moon", time, location=self.location)
+                target = self.get_body("moon", time)
             elif target is SunFlag:
-                target = get_sun(time)
+                target = self.get_body('sun', time)
 
             time, target = self._preprocess_inputs(time, target, grid_times_targets)
 
@@ -1347,7 +1399,7 @@ class Observer(object):
         >>> print("ISO: {0.iso}, JD: {0.jd}".format(sun_rise)) # doctest: +SKIP
         ISO: 2001-02-02 14:02:50.554, JD: 2451943.08531
         """
-        return self.target_rise_time(time, get_sun(time), which, horizon,
+        return self.target_rise_time(time, self.get_body('sun', time), which, horizon,
                                      n_grid_points=n_grid_points)
 
     @u.quantity_input(horizon=u.deg)
@@ -1398,7 +1450,7 @@ class Observer(object):
         >>> print("ISO: {0.iso}, JD: {0.jd}".format(sun_set)) # doctest: +SKIP
         ISO: 2001-02-04 00:35:42.102, JD: 2451944.52479
         """
-        return self.target_set_time(time, get_sun(time), which, horizon,
+        return self.target_set_time(time, self.get_body('sun', time), which, horizon,
                                     n_grid_points=n_grid_points)
 
     def noon(self, time, which='nearest', n_grid_points=150):
@@ -1427,7 +1479,7 @@ class Observer(object):
         `~astropy.time.Time`
             Time at solar noon
         """
-        return self.target_meridian_transit_time(time, get_sun(time), which,
+        return self.target_meridian_transit_time(time, self.get_body('sun', time), which,
                                                  n_grid_points=n_grid_points)
 
     def midnight(self, time, which='nearest', n_grid_points=150):
@@ -1456,7 +1508,7 @@ class Observer(object):
         `~astropy.time.Time`
             Time at solar midnight
         """
-        return self.target_meridian_antitransit_time(time, get_sun(time), which,
+        return self.target_meridian_antitransit_time(time, self.get_body('sun', time), which,
                                                      n_grid_points=n_grid_points)
 
     # Twilight convenience functions
@@ -1813,7 +1865,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        moon = get_body("moon", time, location=self.location, ephemeris=ephemeris)
+        moon = self.get_body("moon", time, ephemeris=ephemeris)
         return self.altaz(time, moon)
 
     def sun_altaz(self, time):
@@ -1842,7 +1894,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        sun = get_sun(time)
+        sun = self.get_body('sun', time)
         return self.altaz(time, sun)
 
     @u.quantity_input(horizon=u.deg)
@@ -1952,7 +2004,7 @@ class Observer(object):
         if not isinstance(time, Time):
             time = Time(time)
 
-        solar_altitude = self.altaz(time, target=get_sun(time), obswl=obswl).alt
+        solar_altitude = self.altaz(time, target=self.get_body('sun', time), obswl=obswl).alt
 
         if solar_altitude.isscalar:
             return bool(solar_altitude < horizon)

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -50,7 +50,7 @@ def _make_cache_key(times, targets):
     """
     # make a tuple from times
     try:
-        timekey = tuple(times.jd) + times.shape
+        timekey = tuple(times.ravel().jd) + times.shape
     except BaseException:        # must be scalar
         timekey = (times.jd,)
     # make hashable thing from targets coords

--- a/astroplan/observer.py
+++ b/astroplan/observer.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from six import string_types
 
 # Standard library
 import sys
@@ -19,7 +20,7 @@ import pytz
 from .exceptions import TargetNeverUpWarning, TargetAlwaysUpWarning
 from .moon import moon_illumination, moon_phase_angle
 from .observer import _make_cache_key
-from .target import MoonFlag, SunFlag, get_skycoord
+from .target import get_skycoord, SunFlag, MoonFlag
 
 
 __all__ = ["Observer"]


### PR DESCRIPTION
# Add cached Sun/Moon calculations in `Observer` class

## Reason for pull 
`astroplan` makes use of the the `astropy` `get_sun` and `get_body` to calculate the position of the Moon and Sun. . Unfortunately these calls are computationally expensive, which can lead to inefficiencies when calculating the positions of the Sun and Moon from scratch each time we need them. As the Sun/Moon positions are only unique for a given Observer location and set of times, it would be more efficient to cache them, rather than recalculating them every time we need them.

## Solution

This pull request adds a `get_body` method to the `Observer` class, which calculates the position of any Solar System body supported by the `astropy` `get_body`, for the current `Observer.location`, at a given `time`. This method caches the results, using the same scheme as alt/az caching (reusing the `_make_cache_key` function , which I had to move to `observer.py` to avoid a circular import).

I then replaced all calls to `get_sun` and `get_body` in `Observer` and in `constraints.py` where the `Observer` class is used, with this method.

This ensures that for a given `Observer` and `time`, the positions of the Sun and Moon are only ever calculated once. In my own code, this results in a 4x speedup when calculating multiple target visibilities, after an initial calculation.

## Possible issues

### Replacement  of `get_sun` calls
I replaced `get_sun` with `Observer.get_body` calls, which means that `get_sun` calls that previously did not pass the `location` parameter, now do. I do not believe this will make any difference, and should be both negligibly different and  "more correct". However,  there is a possibility I misunderstood the reason for not passing location to `get_sun` in some cases. The solution to this would be to create a second `get_sun` method that mimics exactly the previous use, but with caching.

To investigate this, I used the `Observer.altaz` method to calculate the Alt/Az of the Sun, for the example given in the inline code comment. The use of `get_body` with `location` set instead of a plain `get_sun` does result in different values, but it differs by a negligible amount (angular separation of 0.005 arc-seconds between the two values). 

### The `get_body` method name
Stylistic choice, but it might be better to use a different method name than the astropy `get_body` for this, to avoid confusion? I wavered between `get_body` and `_get_body`.

